### PR TITLE
fix: update semantic-release and @semantic-release/npm to stable versions

### DIFF
--- a/scripts/npm-release/package.json
+++ b/scripts/npm-release/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
-    "@semantic-release/npm": "13.0.0-alpha.5",
+    "@semantic-release/npm": "^13.1.5",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
@@ -11,7 +11,7 @@
     "@semantic-release/release-notes-generator": "^14.0.3",
     "@semantic-release/github": "^11.0.3",
     "conventional-changelog-conventionalcommits": "^5.0.0",
-    "semantic-release": "25.0.0-alpha.4",
+    "semantic-release": "^25.0.3",
     "undici": "^5.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

`@semantic-release/npm@13.0.0-alpha.5` depends on `npm@github:npm/cli#oidc`, but the `oidc` branch has been deleted from the `npm/cli` repo, causing `npm install` to fail:

```
npm error command git --no-replace-objects checkout oidc
npm error error: pathspec 'oidc' did not match any file(s) known to git
```

This breaks all downstream release workflows (e.g. [cnpm/unpkg-white-list](https://github.com/cnpm/unpkg-white-list/actions/runs/22700918457/job/65844808852)).

## Fix

- `@semantic-release/npm`: `13.0.0-alpha.5` → `^13.1.5` (stable, uses `npm@^11.6.2` from registry)
- `semantic-release`: `25.0.0-alpha.4` → `^25.0.3` (stable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation dependencies to stable versions for enhanced reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->